### PR TITLE
fix: update environment support for KaiOS browser

### DIFF
--- a/lib/config/browserslistTargetHandler.js
+++ b/lib/config/browserslistTargetHandler.js
@@ -120,7 +120,7 @@ const resolve = browsers => {
 		and_qq: [10, 4],
 		// baidu: Not supported
 		// and_uc: Not supported
-		// kaios: Not supported
+		kaios: [3, 0],
 		node: [12, 17]
 	});
 
@@ -187,7 +187,7 @@ const resolve = browsers => {
 			// and_qq: Unknown support
 			// baidu: Unknown support
 			// and_uc: Unknown support
-			// kaios: Unknown support
+			kaios: [3, 0],
 			node: [0, 12]
 		}),
 		destructuring: rawChecker({
@@ -206,7 +206,7 @@ const resolve = browsers => {
 			// and_qq: Unknown support
 			// baidu: Unknown support
 			// and_uc: Unknown support
-			// kaios: Unknown support
+			kaios: [2, 5],
 			node: [6, 0]
 		}),
 		bigIntLiteral: rawChecker({
@@ -225,7 +225,7 @@ const resolve = browsers => {
 			// and_qq: Not supported
 			// baidu: Not supported
 			// and_uc: Not supported
-			// kaios: Not supported
+			kaios: [3, 0],
 			node: [10, 4]
 		}),
 		// Support syntax `import` and `export` and no limitations and bugs on Node.js
@@ -246,7 +246,7 @@ const resolve = browsers => {
 			and_qq: [10, 4],
 			// baidu: Not supported
 			// and_uc: Not supported
-			// kaios: Not supported
+			kaios: [3, 0],
 			node: [12, 17]
 		}),
 		dynamicImport: es6DynamicImport,
@@ -269,7 +269,7 @@ const resolve = browsers => {
 			// and_qq: Unknown support
 			// baidu: Unknown support
 			// and_uc: Unknown support
-			// kaios: Unknown support
+			kaios: [3, 0],
 			node: 12
 		}),
 		optionalChaining: rawChecker({
@@ -288,7 +288,7 @@ const resolve = browsers => {
 			// and_qq: Not supported
 			// baidu: Not supported
 			// and_uc: Not supported
-			// kaios: Not supported
+			kaios: [3, 0],
 			node: 14
 		}),
 		templateLiteral: rawChecker({


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

Addresses issues for KaiOS browser mentioned in https://github.com/webpack/webpack/issues/14226#issuecomment-1560486380 by adding version 3.0 support to various environment features.

<!-- cspell:disable-next-line -->

copilot:summary

## Details

KaiOS browser [version 3.0 is based on Gecko 84](https://en.wikipedia.org/wiki/KaiOS#Release_history), so this PR simply adds it wherever it makes sense based on the Firefox support.  Note that for big features like dynamic import, this brings Webpack in line with [CanIUse data](https://caniuse.com/es6-module-dynamic-import).

<!-- cspell:disable-next-line -->

copilot:walkthrough
